### PR TITLE
Update tests to no longer use qa-share methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,6 @@
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>org.alfresco</groupId>
-            <artifactId>qa-share</artifactId>
-            <version>5.0.1-SNAPSHOT</version>
-        </dependency>
-        <dependency>
             <groupId>org.alfresco.test</groupId>
             <artifactId>alfresco-testng</artifactId>
             <version>1.1</version>

--- a/src/test/java/org/alfresco/test/wqs/share/WqsDLIntegrationTests.java
+++ b/src/test/java/org/alfresco/test/wqs/share/WqsDLIntegrationTests.java
@@ -5,6 +5,7 @@ import org.alfresco.po.share.dashlet.SiteWebQuickStartDashlet;
 import org.alfresco.po.share.dashlet.WebQuickStartOptions;
 import org.alfresco.po.share.enums.Dashlets;
 import org.alfresco.po.share.site.CustomiseSiteDashboardPage;
+import org.alfresco.po.share.site.CustomizeSitePage;
 import org.alfresco.po.share.site.SiteDashboardPage;
 import org.alfresco.po.share.site.SitePageType;
 import org.alfresco.po.share.site.datalist.DataListPage;
@@ -13,7 +14,6 @@ import org.alfresco.po.share.site.datalist.lists.VisitorFeedbackList;
 import org.alfresco.po.share.site.document.DocumentLibraryPage;
 import org.alfresco.po.share.util.SiteUtil;
 import org.alfresco.po.share.wqs.*;
-import org.alfresco.share.util.ShareUserDashboard;
 import org.alfresco.test.FailedTestListener;
 import org.alfresco.test.util.SiteService;
 import org.alfresco.test.wqs.uitl.AbstractWQS;
@@ -22,6 +22,9 @@ import org.openqa.selenium.remote.UnreachableBrowserException;
 import org.springframework.social.alfresco.api.entities.Site;
 import org.testng.Assert;
 import org.testng.annotations.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Listeners(FailedTestListener.class)
 public class WqsDLIntegrationTests extends AbstractWQS
@@ -39,9 +42,7 @@ public class WqsDLIntegrationTests extends AbstractWQS
     {
         super.setup();
         testName = this.getClass().getSimpleName();
-        // newsName = "cont2" + getFileName(testName) + ".html";
-        // siteName = getSiteName(testName);
-//        siteName = "Share-55952SiteNameZ2";
+
         siteName = getSiteName(testName) + System.currentTimeMillis();
         logger.info("Start tests:" + testName);
 
@@ -89,7 +90,10 @@ public class WqsDLIntegrationTests extends AbstractWQS
         wqsDashlet.waitForImportMessage();
 
         // Data Lists component is added to the site
-        ShareUserDashboard.addPageToSite(drone, siteName, SitePageType.DATA_LISTS);
+        CustomizeSitePage customizeSitePage = siteDashboardPage.getSiteNav().selectCustomizeSite().render();
+        List<SitePageType> addPageTypes = new ArrayList<SitePageType>();
+        addPageTypes.add(SitePageType.DATA_LISTS);
+        customizeSitePage.addPages(addPageTypes).render();
 
         // Site Dashboard is rendered with Data List link
         SiteUtil.openSiteDashboard(drone, siteName).render();

--- a/src/test/java/org/alfresco/test/wqs/web/MainPage.java
+++ b/src/test/java/org/alfresco/test/wqs/web/MainPage.java
@@ -4,17 +4,21 @@ package org.alfresco.test.wqs.web;
  * Created by P3700473 on 12/2/2014.
  */
 
+import org.alfresco.po.share.ShareUtil;
 import org.alfresco.po.share.dashlet.SiteWebQuickStartDashlet;
 import org.alfresco.po.share.dashlet.WebQuickStartOptions;
 import org.alfresco.po.share.enums.Dashlets;
 import org.alfresco.po.share.site.SiteDashboardPage;
 import org.alfresco.po.share.site.document.DocumentLibraryPage;
 import org.alfresco.po.share.site.document.EditDocumentPropertiesPage;
+import org.alfresco.po.share.util.SiteUtil;
 import org.alfresco.po.share.wqs.*;
 import org.alfresco.share.util.ShareUser;
 import org.alfresco.share.util.ShareUserDashboard;
+import org.alfresco.test.util.SiteService;
 import org.alfresco.test.wqs.uitl.AbstractWQS;
 import org.apache.log4j.Logger;
+import org.springframework.social.alfresco.api.entities.Site;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -31,7 +35,7 @@ import static org.hamcrest.Matchers.containsString;
  * Created by Lucian Tuca on 12/02/2014.
  */
 public class MainPage extends AbstractWQS
-    {
+{
     private static final Logger logger = Logger.getLogger(MainPage.class);
     private final String ALFRESCO_QUICK_START = "Alfresco Quick Start";
     private final String QUICK_START_EDITORIAL = "Quick Start Editorial";
@@ -49,46 +53,47 @@ public class MainPage extends AbstractWQS
     @Override
     @BeforeClass(alwaysRun = true)
     public void setup() throws Exception
-        {
+    {
         super.setup();
 
         testName = this.getClass().getSimpleName();
         siteName = testName;
         hostName = (shareUrl).replaceAll(".*\\//|\\:.*", "");
         try
-            {
+        {
             ipAddress = InetAddress.getByName(hostName).toString().replaceAll(".*/", "");
             logger.info("Ip address from Alfresco server was obtained");
-            } catch (UnknownHostException | SecurityException e)
-            {
+        } catch (UnknownHostException | SecurityException e)
+        {
             logger.error("Ip address from Alfresco server could not be obtained");
-            }
+        }
 
         ;
         wqsURL = siteName + ":8080/wcmqs";
         logger.info(" wcmqs url : " + wqsURL);
         logger.info("Start Tests from: " + testName);
-        }
+    }
 
     @AfterClass(alwaysRun = true)
     public void tearDown()
-        {
+    {
         super.tearDown();
-        }
+    }
 
     @Test(groups = {"DataPrepWQS"})
     public void dataPrep_AONE() throws Exception
-        {
+    {
         // User login
         // ---- Step 1 ----
         // ---- Step Action -----
         // WCM Quick Start is installed; - is not required to be executed automatically
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
 
         // ---- Step 2 ----
         // ---- Step Action -----
         // Site "My Web Site" is created in Alfresco Share;
-        ShareUser.createSite(drone, siteName, SITE_VISIBILITY_PUBLIC);
+        SiteService siteService = (SiteService) ctx.getBean("siteService");
+        siteService.create(ADMIN_USERNAME, ADMIN_PASSWORD, DOMAIN_FREE, siteName, "", Site.Visibility.PUBLIC);
 
         // ---- Step 3 ----
         // ---- Step Action -----
@@ -99,7 +104,7 @@ public class MainPage extends AbstractWQS
         wqsDashlet.clickImportButtton();
 
         //Change property for quick start to sitename
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+        DocumentLibraryPage documentLibPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder("Alfresco Quick Start");
         EditDocumentPropertiesPage documentPropertiesPage = documentLibPage.getFileDirectoryInfo("Quick Start Editorial").selectEditProperties()
                 .render();
@@ -116,14 +121,14 @@ public class MainPage extends AbstractWQS
                 + " >> %WINDIR%\\System32\\Drivers\\Etc\\hosts";
         Runtime.getRuntime().exec(setHostAddress);
 
-        }
+    }
 
     /*
     * AONE-5656 Main page
     */
     @Test(groups = {"WQS"})
     public void AONE_5656() throws Exception
-        {
+    {
 
         // ---- Step 1 ----
         // ---- Step action ----
@@ -169,14 +174,14 @@ public class MainPage extends AbstractWQS
         Assert.assertTrue(mainPage.isLatestBlogArticlesDisplayed());
 
         System.out.println("a");
-        }
+    }
 
     /*
     * AONE-5657 Verify correct navigation from main page
     */
     @Test(groups = {"WQS"})
     public void AONE_5657() throws Exception
-        {
+    {
 
         navigateTo(wqsURL);
         WcmqsHomePage mainPage = new WcmqsHomePage(drone).render();
@@ -249,14 +254,14 @@ public class MainPage extends AbstractWQS
         blogPage.clickAlfrescoLink();
         pageTitle = drone.getTitle();
         Assert.assertTrue(pageTitle.contains("Alfresco"));
-        }
+    }
 
     /*
     * AONE-5658 Opening articles from main page
     */
     @Test(groups = {"WQS"})
     public void AONE_5658() throws Exception
-        {
+    {
 
         navigateTo(wqsURL);
         WcmqsHomePage mainPage = new WcmqsHomePage(drone).render();
@@ -424,14 +429,14 @@ public class MainPage extends AbstractWQS
         mainPage.clickOnSlideShowReadme(3);
         assertThat("Verify if the correct page opened ", mainPage.getTitle(), containsString(WcmqsNewsPage.CREDIT_CARDS));
 
-        }
+    }
 
     /*
     * AONE-5660 Adding new section in wcmqs site
     */
     @Test(groups = {"WQS"})
     public void AONE_5660() throws Exception
-        {
+    {
 
         // ---- Step 1 ----
         // ---- Step action ----
@@ -439,9 +444,9 @@ public class MainPage extends AbstractWQS
         // ---- Expected results ----
         // root folder is opened;
 
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
 
-        DocumentLibraryPage documentLibraryPage = ShareUser.openSitesDocumentLibrary(drone, siteName).render();
+        DocumentLibraryPage documentLibraryPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(ALFRESCO_QUICK_START).render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(QUICK_START_EDITORIAL).render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(ROOT).render();
@@ -477,42 +482,42 @@ public class MainPage extends AbstractWQS
         waitAndOpenNewSection(homePage, ACCOUNTING, 4);
         String pageTitle = drone.getTitle();
 
-        }
+    }
 
     public void navigateTo(String url)
-        {
+    {
         drone.navigateTo(url);
-        }
+    }
 
     private void waitAndOpenNewSection(WcmqsHomePage homePage, String menuOption, int minutesToWait)
-        {
+    {
         int waitInMilliSeconds = 3000;
         int maxTimeWaitInMilliSeconds = 60000 * minutesToWait;
         boolean sectionFound = false;
 
         while (!sectionFound && maxTimeWaitInMilliSeconds > 0)
-            {
+        {
             try
-                {
+            {
                 homePage.selectMenu(menuOption);
                 sectionFound = true;
-                } catch (Exception e)
-                {
+            } catch (Exception e)
+            {
                 synchronized (this)
-                    {
+                {
                     try
-                        {
+                    {
                         this.wait(waitInMilliSeconds);
-                        } catch (InterruptedException ex)
-                        {
-                        }
+                    } catch (InterruptedException ex)
+                    {
                     }
+                }
                 drone.refresh();
                 maxTimeWaitInMilliSeconds = maxTimeWaitInMilliSeconds - waitInMilliSeconds;
-                }
-
             }
 
         }
 
     }
+
+}

--- a/src/test/java/org/alfresco/test/wqs/web/awe/CreatingItemsViaAWE.java
+++ b/src/test/java/org/alfresco/test/wqs/web/awe/CreatingItemsViaAWE.java
@@ -1,16 +1,18 @@
 package org.alfresco.test.wqs.web.awe;
 
+import org.alfresco.po.share.ShareUtil;
 import org.alfresco.po.share.dashlet.SiteWebQuickStartDashlet;
 import org.alfresco.po.share.dashlet.WebQuickStartOptions;
 import org.alfresco.po.share.enums.Dashlets;
 import org.alfresco.po.share.site.SiteDashboardPage;
 import org.alfresco.po.share.site.document.*;
+import org.alfresco.po.share.util.SiteUtil;
 import org.alfresco.po.share.wqs.*;
-import org.alfresco.share.util.ShareUser;
-import org.alfresco.share.util.ShareUserDashboard;
 import org.alfresco.test.FailedTestListener;
+import org.alfresco.test.util.SiteService;
 import org.alfresco.test.wqs.uitl.AbstractWQS;
 import org.apache.log4j.Logger;
+import org.springframework.social.alfresco.api.entities.Site;
 import org.testng.Assert;
 import org.testng.annotations.*;
 
@@ -187,9 +189,9 @@ public class CreatingItemsViaAWE extends AbstractWQS {
         String foundTitle;
         String foundContent;
 
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
 
-        DocumentLibraryPage documentLibraryPage = ShareUser.openSitesDocumentLibrary(drone, siteName).render();
+        DocumentLibraryPage documentLibraryPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(ALFRESCO_QUICK_START).render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(QUICK_START_EDITORIAL).render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(ROOT).render();
@@ -209,12 +211,13 @@ public class CreatingItemsViaAWE extends AbstractWQS {
         // ---- Step 1 ----
         // ---- Step Action -----
         // WCM Quick Start is installed; - is not required to be executed automatically
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
 
         // ---- Step 2 ----
         // ---- Step Action -----
         // Site "My Web Site" is created in Alfresco Share;
-        ShareUser.createSite(drone, siteName, SITE_VISIBILITY_PUBLIC);
+        SiteService siteService = (SiteService) ctx.getBean("siteService");
+        siteService.create(ADMIN_USERNAME, ADMIN_PASSWORD, DOMAIN_FREE, siteName, "", Site.Visibility.PUBLIC);
 
         // ---- Step 3 ----
         // ---- Step Action -----
@@ -226,7 +229,8 @@ public class CreatingItemsViaAWE extends AbstractWQS {
         wqsDashlet.waitForImportMessage();
 
         //Change property for quick start to sitename
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+
+        DocumentLibraryPage documentLibPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder("Alfresco Quick Start");
         EditDocumentPropertiesPage documentPropertiesPage = documentLibPage.getFileDirectoryInfo("Quick Start Editorial").selectEditProperties()
                 .render();
@@ -391,9 +395,9 @@ public class CreatingItemsViaAWE extends AbstractWQS {
         String foundTitle;
         String foundContent;
 
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
 
-        DocumentLibraryPage documentLibraryPage = ShareUser.openSitesDocumentLibrary(drone, siteName).render();
+        DocumentLibraryPage documentLibraryPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(ALFRESCO_QUICK_START).render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(QUICK_START_EDITORIAL).render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(ROOT).render();
@@ -506,14 +510,14 @@ public class CreatingItemsViaAWE extends AbstractWQS {
         String articleContent = testName + System.currentTimeMillis() + "_content";
         siteName = getSiteName(testName);
 
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
 
         // ---- Step 1 ----
         // ---- Step Actions ----
         // Create an HTML article in Quick Start Editorial > root > news > global(e.g. article10.html).
         // ---- Expected results ----
         // HTML article is successfully created;
-        DocumentLibraryPage documentLibraryPage = ShareUser.openSitesDocumentLibrary(drone, siteName).render();
+        DocumentLibraryPage documentLibraryPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(ALFRESCO_QUICK_START).render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(QUICK_START_EDITORIAL).render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(ROOT).render();
@@ -533,8 +537,8 @@ public class CreatingItemsViaAWE extends AbstractWQS {
         // Navigate to Quick Start Editorial > root > news > global > collections > section.articles.
         // ---- Expected results ----
         // Section.articles folder is opened;
-        ShareUser.openSiteDashboard(drone, siteName);
-        documentLibraryPage = ShareUser.openSitesDocumentLibrary(drone, siteName).render();
+        SiteUtil.openSiteDashboard(drone, siteName).render();
+        documentLibraryPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(ALFRESCO_QUICK_START).render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(QUICK_START_EDITORIAL).render();
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder(ROOT).render();

--- a/src/test/java/org/alfresco/test/wqs/web/awe/DeleteItemsViaAWE.java
+++ b/src/test/java/org/alfresco/test/wqs/web/awe/DeleteItemsViaAWE.java
@@ -1,16 +1,18 @@
 package org.alfresco.test.wqs.web.awe;
 
+import org.alfresco.po.share.ShareUtil;
 import org.alfresco.po.share.dashlet.SiteWebQuickStartDashlet;
 import org.alfresco.po.share.dashlet.WebQuickStartOptions;
 import org.alfresco.po.share.enums.Dashlets;
 import org.alfresco.po.share.site.SiteDashboardPage;
 import org.alfresco.po.share.site.document.DocumentLibraryPage;
 import org.alfresco.po.share.site.document.EditDocumentPropertiesPage;
+import org.alfresco.po.share.util.SiteUtil;
 import org.alfresco.po.share.wqs.*;
-import org.alfresco.share.util.ShareUser;
-import org.alfresco.share.util.ShareUserDashboard;
+import org.alfresco.test.util.SiteService;
 import org.alfresco.test.wqs.uitl.AbstractWQS;
 import org.apache.log4j.Logger;
+import org.springframework.social.alfresco.api.entities.Site;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -67,12 +69,13 @@ public class DeleteItemsViaAWE extends AbstractWQS {
         // ---- Step 1 ----
         // ---- Step Action -----
         // WCM Quick Start is installed; - is not required to be executed automatically
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
 
         // ---- Step 2 ----
         // ---- Step Action -----
         // Site "My Web Site" is created in Alfresco Share;
-        ShareUser.createSite(drone, siteName, SITE_VISIBILITY_PUBLIC);
+        SiteService siteService = (SiteService) ctx.getBean("siteService");
+        siteService.create(ADMIN_USERNAME, ADMIN_PASSWORD, DOMAIN_FREE, siteName, "", Site.Visibility.PUBLIC);
 
         // ---- Step 3 ----
         // ---- Step Action -----
@@ -84,7 +87,7 @@ public class DeleteItemsViaAWE extends AbstractWQS {
         wqsDashlet.waitForImportMessage();
 
         //Change property for quick start to sitename
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+        DocumentLibraryPage documentLibPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder("Alfresco Quick Start");
         EditDocumentPropertiesPage documentPropertiesPage = documentLibPage.getFileDirectoryInfo("Quick Start Editorial").selectEditProperties()
                 .render();
@@ -169,8 +172,8 @@ public class DeleteItemsViaAWE extends AbstractWQS {
         // Go to Share "My Web Site" document library (Alfresco Quick Start/Quick Start Editorial/root/blog) and verify blog1.html file;
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly, file is removed and not displayed in the folder;
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
+        DocumentLibraryPage documentLibPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder(ALFRESCO_QUICK_START);
         documentLibPage.selectFolder(QUICK_START_EDITORIAL);
         documentLibPage.selectFolder(ROOT_FOLDER);
@@ -248,7 +251,7 @@ public class DeleteItemsViaAWE extends AbstractWQS {
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly, file is removed and not displayed in the folder;
         drone.navigateTo(shareUrl);
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+        DocumentLibraryPage documentLibPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder(ALFRESCO_QUICK_START);
         documentLibPage.selectFolder(QUICK_START_EDITORIAL);
         documentLibPage.selectFolder(ROOT_FOLDER);
@@ -326,7 +329,7 @@ public class DeleteItemsViaAWE extends AbstractWQS {
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly, file is removed and not displayed in the folder;
         drone.navigateTo(shareUrl);
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+        DocumentLibraryPage documentLibPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder(ALFRESCO_QUICK_START);
         documentLibPage.selectFolder(QUICK_START_EDITORIAL);
         documentLibPage.selectFolder(ROOT_FOLDER);
@@ -402,7 +405,7 @@ public class DeleteItemsViaAWE extends AbstractWQS {
         // Changes made via AWE are dislpayed correctly, file is removed and not displayed in the folder;
         drone.navigateTo(shareUrl);
 
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+        DocumentLibraryPage documentLibPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder(ALFRESCO_QUICK_START);
         documentLibPage.selectFolder(QUICK_START_EDITORIAL);
         documentLibPage.selectFolder(ROOT_FOLDER);
@@ -480,7 +483,7 @@ public class DeleteItemsViaAWE extends AbstractWQS {
         // Changes made via AWE are dislpayed correctly, file is removed and not displayed in the folder;
         drone.navigateTo(shareUrl);
 
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+        DocumentLibraryPage documentLibPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder(ALFRESCO_QUICK_START);
         documentLibPage.selectFolder(QUICK_START_EDITORIAL);
         documentLibPage.selectFolder(ROOT_FOLDER);
@@ -558,7 +561,7 @@ public class DeleteItemsViaAWE extends AbstractWQS {
         // Changes made via AWE are dislpayed correctly, file is removed and not displayed in the folder;
         drone.navigateTo(shareUrl);
 
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+        DocumentLibraryPage documentLibPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder(ALFRESCO_QUICK_START);
         documentLibPage.selectFolder(QUICK_START_EDITORIAL);
         documentLibPage.selectFolder(ROOT_FOLDER);
@@ -635,7 +638,7 @@ public class DeleteItemsViaAWE extends AbstractWQS {
         // Changes made via AWE are dislpayed correctly, file is removed and not displayed in the folder;
         drone.navigateTo(shareUrl);
 
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+        DocumentLibraryPage documentLibPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder(ALFRESCO_QUICK_START);
         documentLibPage.selectFolder(QUICK_START_EDITORIAL);
         documentLibPage.selectFolder(ROOT_FOLDER);
@@ -713,7 +716,7 @@ public class DeleteItemsViaAWE extends AbstractWQS {
         // Changes made via AWE are dislpayed correctly, file is removed and not displayed in the folder;
         drone.navigateTo(shareUrl);
 
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+        DocumentLibraryPage documentLibPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder(ALFRESCO_QUICK_START);
         documentLibPage.selectFolder(QUICK_START_EDITORIAL);
         documentLibPage.selectFolder(ROOT_FOLDER);
@@ -791,7 +794,7 @@ public class DeleteItemsViaAWE extends AbstractWQS {
         // Changes made via AWE are dislpayed correctly, file is removed and not displayed in the folder;
         drone.navigateTo(shareUrl);
 
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+        DocumentLibraryPage documentLibPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder(ALFRESCO_QUICK_START);
         documentLibPage.selectFolder(QUICK_START_EDITORIAL);
         documentLibPage.selectFolder(ROOT_FOLDER);

--- a/src/test/java/org/alfresco/test/wqs/web/awe/EditingItemsTests.java
+++ b/src/test/java/org/alfresco/test/wqs/web/awe/EditingItemsTests.java
@@ -1,6 +1,7 @@
 package org.alfresco.test.wqs.web.awe;
 
 import org.alfresco.po.share.ShareLink;
+import org.alfresco.po.share.ShareUtil;
 import org.alfresco.po.share.dashlet.SiteWebQuickStartDashlet;
 import org.alfresco.po.share.dashlet.WebQuickStartOptions;
 import org.alfresco.po.share.enums.Dashlets;
@@ -13,8 +14,10 @@ import org.alfresco.po.share.wqs.*;
 import org.alfresco.share.util.ShareUser;
 import org.alfresco.share.util.ShareUserDashboard;
 import org.alfresco.test.FailedTestListener;
+import org.alfresco.test.util.SiteService;
 import org.alfresco.test.wqs.uitl.AbstractWQS;
 import org.apache.log4j.Logger;
+import org.springframework.social.alfresco.api.entities.Site;
 import org.testng.Assert;
 import org.testng.annotations.*;
 
@@ -85,12 +88,13 @@ public class EditingItemsTests extends AbstractWQS {
         // ---- Step 1 ----
         // ---- Step Action -----
         // WCM Quick Start is installed; - is not required to be executed automatically
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
 
         // ---- Step 2 ----
         // ---- Step Action -----
         // Site "My Web Site" is created in Alfresco Share;
-        ShareUser.createSite(drone, siteName, SITE_VISIBILITY_PUBLIC);
+        SiteService siteService = (SiteService) ctx.getBean("siteService");
+        siteService.create(ADMIN_USERNAME, ADMIN_PASSWORD, DOMAIN_FREE, siteName, "", Site.Visibility.PUBLIC);
 
         // ---- Step 3 ----
         // ---- Step Action -----
@@ -196,7 +200,7 @@ public class EditingItemsTests extends AbstractWQS {
         // Go to Share "My Web Site" document library (Alfresco Quick Start/Quick Start Editorial/root/blog) and verify blog1.html file;
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
         DocumentLibraryPage documentLibraryPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
         documentLibraryPage = navigateToWqsFolderFromRoot(documentLibraryPage, "blog");
 
@@ -294,7 +298,7 @@ public class EditingItemsTests extends AbstractWQS {
         // Go to Share "My Web Site" document library (Alfresco Quick Start/Quick Start Editorial/root/blog) and verify blog2.html file;
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
         DocumentLibraryPage documentLibraryPage = ShareUser.openSiteDocumentLibraryFromSearch(drone, siteName);
         documentLibraryPage = navigateToWqsFolderFromRoot(documentLibraryPage, "blog");
 
@@ -390,7 +394,7 @@ public class EditingItemsTests extends AbstractWQS {
         // Go to Share "My Web Site" document library (Alfresco Quick Start/Quick Start Editorial/root/blog) and verify blog3.html file;
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
         DocumentLibraryPage documentLibraryPage = ShareUser.openSiteDocumentLibraryFromSearch(drone, siteName);
         documentLibraryPage = navigateToWqsFolderFromRoot(documentLibraryPage, "blog");
 
@@ -484,7 +488,7 @@ public class EditingItemsTests extends AbstractWQS {
         // Go to Share "My Web Site" document library (Alfresco Quick Start/Quick Start Editorial/root/news/global) and verify article4.html file;
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
         DocumentLibraryPage documentLibraryPage = ShareUser.openSiteDocumentLibraryFromSearch(drone, siteName);
         documentLibraryPage = navigateToWqsFolderFromRoot(documentLibraryPage, "news");
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder("global").render();
@@ -587,7 +591,7 @@ public class EditingItemsTests extends AbstractWQS {
         // Go to Share "My Web Site" document library (Alfresco Quick Start/Quick Start Editorial/root/news/global) and verify article3.html file;
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
         DocumentLibraryPage documentLibraryPage = ShareUser.openSiteDocumentLibraryFromSearch(drone, siteName);
         documentLibraryPage = navigateToWqsFolderFromRoot(documentLibraryPage, "news");
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder("global").render();
@@ -682,7 +686,7 @@ public class EditingItemsTests extends AbstractWQS {
         // Go to Share "My Web Site" document library (Alfresco Quick Start/Quick Start Editorial/root/news/companies) and verify article2.html file;
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
         DocumentLibraryPage documentLibraryPage = ShareUser.openSiteDocumentLibraryFromSearch(drone, siteName);
         documentLibraryPage = navigateToWqsFolderFromRoot(documentLibraryPage, "news");
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder("companies").render();
@@ -777,7 +781,7 @@ public class EditingItemsTests extends AbstractWQS {
         // Go to Share "My Web Site" document library (Alfresco Quick Start/Quick Start Editorial/root/news/companies) and verify article1.html file;
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
         DocumentLibraryPage documentLibraryPage = ShareUser.openSiteDocumentLibraryFromSearch(drone, siteName);
         documentLibraryPage = navigateToWqsFolderFromRoot(documentLibraryPage, "news");
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder("companies").render();
@@ -872,7 +876,7 @@ public class EditingItemsTests extends AbstractWQS {
         // Go to Share "My Web Site" document library (Alfresco Quick Start/Quick Start Editorial/root/news/markets) and verify article6.html file;
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
         DocumentLibraryPage documentLibraryPage = ShareUser.openSiteDocumentLibraryFromSearch(drone, siteName);
         documentLibraryPage = navigateToWqsFolderFromRoot(documentLibraryPage, "news");
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder("markets").render();
@@ -967,7 +971,7 @@ public class EditingItemsTests extends AbstractWQS {
         // Go to Share "My Web Site" document library (Alfresco Quick Start/Quick Start Editorial/root/news/markets) and verify article5.html file;
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
         DocumentLibraryPage documentLibraryPage = ShareUser.openSiteDocumentLibraryFromSearch(drone, siteName);
         documentLibraryPage = navigateToWqsFolderFromRoot(documentLibraryPage, "news");
         documentLibraryPage = (DocumentLibraryPage) documentLibraryPage.selectFolder("markets").render();
@@ -1062,7 +1066,7 @@ public class EditingItemsTests extends AbstractWQS {
         // Go to Share "My Web Site" document library (Alfresco Quick Start/Quick Start Editorial/root/news) and verify slide1.html file;
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
         DocumentLibraryPage documentLibraryPage = ShareUser.openSiteDocumentLibraryFromSearch(drone, siteName);
         documentLibraryPage = navigateToWqsFolderFromRoot(documentLibraryPage, "news");
 
@@ -1157,7 +1161,7 @@ public class EditingItemsTests extends AbstractWQS {
         // Go to Share "My Web Site" document library (Alfresco Quick Start/Quick Start Editorial/root/news) and verify slide2.html file;
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
         DocumentLibraryPage documentLibraryPage = ShareUser.openSiteDocumentLibraryFromSearch(drone, siteName);
         documentLibraryPage = navigateToWqsFolderFromRoot(documentLibraryPage, "news");
 
@@ -1253,7 +1257,7 @@ public class EditingItemsTests extends AbstractWQS {
         // Go to Share "My Web Site" document library (Alfresco Quick Start/Quick Start Editorial/root/news) and verify slide3.html file;
         // ---- Expected results ----
         // Changes made via AWE are dislpayed correctly
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
         DocumentLibraryPage documentLibraryPage = ShareUser.openSiteDocumentLibraryFromSearch(drone, siteName);
         documentLibraryPage = navigateToWqsFolderFromRoot(documentLibraryPage, "news");
 

--- a/src/test/java/org/alfresco/test/wqs/web/awe/EditingItemsViaAWE.java
+++ b/src/test/java/org/alfresco/test/wqs/web/awe/EditingItemsViaAWE.java
@@ -1,5 +1,6 @@
 package org.alfresco.test.wqs.web.awe;
 
+import org.alfresco.po.share.ShareUtil;
 import org.alfresco.po.share.dashlet.SiteWebQuickStartDashlet;
 import org.alfresco.po.share.dashlet.WebQuickStartOptions;
 import org.alfresco.po.share.enums.Dashlets;
@@ -13,9 +14,11 @@ import org.alfresco.po.share.wqs.*;
 import org.alfresco.share.util.ShareUser;
 import org.alfresco.share.util.ShareUserDashboard;
 import org.alfresco.test.FailedTestListener;
+import org.alfresco.test.util.SiteService;
 import org.alfresco.test.wqs.uitl.AbstractWQS;
 import org.apache.log4j.Logger;
 import org.openqa.selenium.Keys;
+import org.springframework.social.alfresco.api.entities.Site;
 import org.testng.Assert;
 import org.testng.annotations.*;
 
@@ -70,12 +73,13 @@ public class EditingItemsViaAWE extends AbstractWQS {
         // ---- Step 1 ----
         // ---- Step Action -----
         // WCM Quick Start is installed; - is not required to be executed automatically
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
 
         // ---- Step 2 ----
         // ---- Step Action -----
         // Site "My Web Site" is created in Alfresco Share;
-        ShareUser.createSite(drone, siteName, SITE_VISIBILITY_PUBLIC);
+        SiteService siteService = (SiteService) ctx.getBean("siteService");
+        siteService.create(ADMIN_USERNAME, ADMIN_PASSWORD, DOMAIN_FREE, siteName, "", Site.Visibility.PUBLIC);
 
         // ---- Step 3 ----
         // ---- Step Action -----

--- a/src/test/java/org/alfresco/test/wqs/web/awe/GeneralAWE.java
+++ b/src/test/java/org/alfresco/test/wqs/web/awe/GeneralAWE.java
@@ -1,16 +1,20 @@
 package org.alfresco.test.wqs.web.awe;
 
+import org.alfresco.po.share.ShareUtil;
 import org.alfresco.po.share.dashlet.SiteWebQuickStartDashlet;
 import org.alfresco.po.share.dashlet.WebQuickStartOptions;
 import org.alfresco.po.share.enums.Dashlets;
 import org.alfresco.po.share.site.SiteDashboardPage;
 import org.alfresco.po.share.site.document.DocumentLibraryPage;
 import org.alfresco.po.share.site.document.EditDocumentPropertiesPage;
+import org.alfresco.po.share.util.SiteUtil;
 import org.alfresco.po.share.wqs.*;
 import org.alfresco.share.util.ShareUser;
 import org.alfresco.share.util.ShareUserDashboard;
+import org.alfresco.test.util.SiteService;
 import org.alfresco.test.wqs.uitl.AbstractWQS;
 import org.apache.log4j.Logger;
+import org.springframework.social.alfresco.api.entities.Site;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -65,12 +69,13 @@ public class GeneralAWE extends AbstractWQS {
         // ---- Step 1 ----
         // ---- Step Action -----
         // WCM Quick Start is installed; - is not required to be executed automatically
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
 
         // ---- Step 2 ----
         // ---- Step Action -----
         // Site "My Web Site" is created in Alfresco Share;
-        ShareUser.createSite(drone, siteName, SITE_VISIBILITY_PUBLIC);
+        SiteService siteService = (SiteService) ctx.getBean("siteService");
+        siteService.create(ADMIN_USERNAME, ADMIN_PASSWORD, DOMAIN_FREE, siteName, "", Site.Visibility.PUBLIC);
 
         // ---- Step 3 ----
         // ---- Step Action -----
@@ -82,7 +87,7 @@ public class GeneralAWE extends AbstractWQS {
         wqsDashlet.waitForImportMessage();
 
         //Change property for quick start to sitename
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+        DocumentLibraryPage documentLibPage  = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder("Alfresco Quick Start");
         EditDocumentPropertiesPage documentPropertiesPage = documentLibPage.getFileDirectoryInfo("Quick Start Editorial").selectEditProperties()
                 .render();

--- a/src/test/java/org/alfresco/test/wqs/web/contact/ContactWorkflowTests.java
+++ b/src/test/java/org/alfresco/test/wqs/web/contact/ContactWorkflowTests.java
@@ -1,21 +1,25 @@
 package org.alfresco.test.wqs.web.contact;
 
 import org.alfresco.po.share.MyTasksPage;
+import org.alfresco.po.share.ShareUtil;
 import org.alfresco.po.share.dashlet.SiteWebQuickStartDashlet;
 import org.alfresco.po.share.dashlet.WebQuickStartOptions;
 import org.alfresco.po.share.enums.Dashlets;
 import org.alfresco.po.share.site.SiteDashboardPage;
 import org.alfresco.po.share.site.document.DocumentLibraryPage;
 import org.alfresco.po.share.site.document.EditDocumentPropertiesPage;
+import org.alfresco.po.share.util.SiteUtil;
 import org.alfresco.po.share.wqs.WcmqsContactPage;
 import org.alfresco.po.share.wqs.WcmqsHomePage;
 import org.alfresco.share.util.ShareUser;
 import org.alfresco.share.util.ShareUserDashboard;
 import org.alfresco.share.util.ShareUserWorkFlow;
 import org.alfresco.test.FailedTestListener;
+import org.alfresco.test.util.SiteService;
 import org.alfresco.test.wqs.web.search.SearchTests;
 import org.alfresco.test.wqs.uitl.AbstractWQS;
 import org.apache.log4j.Logger;
+import org.springframework.social.alfresco.api.entities.Site;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -79,12 +83,13 @@ public class ContactWorkflowTests extends AbstractWQS
         // ---- Step 1 ----
         // ---- Step Action -----
         // WCM Quick Start is installed; - is not required to be executed automatically
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+            ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
 
         // ---- Step 2 ----
         // ---- Step Action -----
         // Site "My Web Site" is created in Alfresco Share;
-        ShareUser.createSite(drone, siteName, SITE_VISIBILITY_PUBLIC);
+            SiteService siteService = (SiteService) ctx.getBean("siteService");
+            siteService.create(ADMIN_USERNAME, ADMIN_PASSWORD, DOMAIN_FREE, siteName, "", Site.Visibility.PUBLIC);
 
         // ---- Step 3 ----
         // ---- Step Action -----
@@ -95,7 +100,7 @@ public class ContactWorkflowTests extends AbstractWQS
         wqsDashlet.clickImportButtton();
 
         // Change property for quick start to sitename
-        DocumentLibraryPage documentLibPage = ShareUser.openSitesDocumentLibrary(drone, siteName);
+        DocumentLibraryPage documentLibPage = SiteUtil.openSiteFromSearch(drone, siteName).getSiteNav().selectSiteDocumentLibrary().render();
         documentLibPage.selectFolder(ALFRESCO_QUICK_START);
         EditDocumentPropertiesPage documentPropertiesPage = documentLibPage.getFileDirectoryInfo(QUICK_START_EDITORIAL).selectEditProperties().render();
         documentPropertiesPage.setSiteHostname(siteName);
@@ -158,7 +163,7 @@ public class ContactWorkflowTests extends AbstractWQS
         // ---- Expected results ----
         // Admin is logged in Alfresco Share;
 
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
 
         // ---- Step 4 ----
         // ---- Step action ----
@@ -204,7 +209,7 @@ public class ContactWorkflowTests extends AbstractWQS
         // ---- Expected results ----
         // Admin is logged in Alfresco Share;
 
-        ShareUser.login(drone, ADMIN_USERNAME, ADMIN_PASSWORD);
+        ShareUtil.loginAs(drone, shareUrl, ADMIN_USERNAME, ADMIN_PASSWORD);
 
         // ---- Step 2 ----
         // ---- Step action ----


### PR DESCRIPTION
The remaining methods to relocate are:
createContentInCurrentFolder
navigateToMyTasksPage